### PR TITLE
fix: 修复 html 代码高亮

### DIFF
--- a/app/web/templates/history.html
+++ b/app/web/templates/history.html
@@ -220,7 +220,7 @@
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-javascript.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-json.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-css.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-html.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-markup.min.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
PrismJS 默认只提供通用的 `prism‑markup` 组件，并不存在单独的 `prism‑html` 模块